### PR TITLE
AtomPub APIでPOST/PUTする際のXML文書をBOMなしUTF-8で出力する

### DIFF
--- a/core/Smdn.Applications.HatenaBlogTools/src/Smdn.Applications.HatenaBlogTools.AtomPublishingProtocol/AtomPubClient.cs
+++ b/core/Smdn.Applications.HatenaBlogTools/src/Smdn.Applications.HatenaBlogTools.AtomPublishingProtocol/AtomPubClient.cs
@@ -26,6 +26,7 @@ using System;
 using System.IO;
 using System.Net;
 using System.Text;
+using System.Xml;
 using System.Xml.Linq;
 
 using Smdn.Net;
@@ -76,8 +77,19 @@ namespace Smdn.Applications.HatenaBlogTools.AtomPublishingProtocol {
 
         req.ContentType = "application/atom+xml";
 
+        var settings = new XmlWriterSettings() {
+          Encoding = new UTF8Encoding(false), // Hatena blog AtomPub API's XML parser does not accept XML documents with BOM
+          NewLineChars = "\n",
+          ConformanceLevel = ConformanceLevel.Document,
+          Indent = true,
+          IndentChars = " ",
+          CloseOutput = false,
+        };
+
         using (var reqStream = req.GetRequestStream()) {
-          requestDocument.Save(reqStream);
+          using (var writer = XmlWriter.Create(reqStream, settings)) {
+            requestDocument.Save(writer);
+          }
         }
 
         return req;


### PR DESCRIPTION
POST/PUTリクエストを行うと`400 XML Parse Failed`が返される。

```
ログインしています ... ログインに成功しました。
投稿しています ('test') ... 400 Bad Request (POST https://blog.hatena.ne.jp/smdn/smdn.hatenablog.jp/atom/entry)
400 XML Parse Failed
失敗しました: BadRequest
```

リクエストのcontent bodyにUTF-8 BOMが含まれていると`XML Parse Failed`となるようなので、リクエストにBOMが含まれないように修正する。

はてなブログAtomPub APIでBOM付きUTF-8のXML文書を扱えなくなった時期は不明。