### PR TITLE
[ReplaceContentText] `--diff-test`が指定されたとき、はてなID/ブログID/APIキーが要求されないようにする

### DIFF
--- a/src/Smdn.HatenaBlogTools.Cli.ReplaceContentText/Main.cs
+++ b/src/Smdn.HatenaBlogTools.Cli.ReplaceContentText/Main.cs
@@ -35,7 +35,7 @@ public partial class ReplaceContentText : CliBase {
     if (
       !ParseCommonCommandLineArgs(
         ref args,
-        new[] { "-diff-test" },
+        new[] { "--diff-test" },
         out var credential
       )
     ) {


### PR DESCRIPTION
FixMixedContentでは、`--diff-test`が指定されたときははてなID/ブログID/APIキーが不要なので指定が要求されない。
ReplaceContentTextでは同様の動作が正しく機能していないので、修正する。

### FixMixedContentの動作
```sh
$ dotnet run -f net6.0 -- --diff-cmd diff --diff-test
2c2
< この行の差分が見えていなければ失敗です
---
> この行の差分が見えていれば成功です
```

### 期待される/修正後のReplaceContentTextの動作
```sh
$ dotnet run -f net6.0 -- --diff-cmd diff --diff-test
2c2
< この行の差分が見えていなければ失敗です
---
> この行の差分が見えていれば成功です
```

### 実際のReplaceContentTextの動作
```sh
$ dotnet run -f net6.0 -- --diff-cmd diff --diff-test
error: --idを指定してください
```