### PR TITLE
.NET 8.0へ更新する

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,15 +26,37 @@ on:
         description: "The project name to run the test."
         required: false
         type: string
+
       os:
         description: "The OS label which run the test on. (ex: ubuntu-22.04, ubuntu-20.04, windows-latest, macos-latest)"
         required: false
         type: string
+
       verbose:
         description: "If true, enables verbose output."
         required: false
         type: boolean
         default: false
+
+      extra_options_common:
+        description: "The common extra options to be set on running the `dotnet restore/build/test` command."
+        required: false
+        type: string
+
+      dotnet_test_options_verbosity_level:
+        description: "The argument to be set to the `--verbosity <LEVEL>` option of the `dotnet test` command. <LEVEL> := q[uiet], m[inimal], n[ormal], d[etailed], diag[nostic]"
+        required: false
+        type: string
+
+      dotnet_test_options_framework:
+        description: "The argument to be set to the `--framework <FRAMEWORK>` option of the `dotnet test` command."
+        required: false
+        type: string
+
+      dotnet_test_options_filter_expression:
+        description: "The argument to be set to the `--filter <EXPRESSION>` option of the `dotnet test` command."
+        required: false
+        type: string
 
 jobs:
   prerequisites:
@@ -43,7 +65,7 @@ jobs:
       os: ${{ steps.input-prerequisites.outputs.os }}
       verbose: ${{ steps.input-prerequisites.outputs.verbose }}
     env:
-      RUNS_ON_OS_LIST_DEFAULT: 'ubuntu-22.04, ubuntu-20.04, windows-latest, macos-latest'
+      RUNS_ON_OS_LIST_DEFAULT: 'ubuntu-24.04, ubuntu-22.04, ubuntu-20.04, windows-latest, macos-latest'
     steps:
     - name: Determine prerequisites
       id: input-prerequisites
@@ -61,14 +83,20 @@ jobs:
         fi
 
   run-test:
-    uses: smdn/Smdn.Fundamentals/.github/workflows/test.yml@workflows/test-v1.1.1
+    uses: smdn/Smdn.Fundamentals/.github/workflows/test.yml@workflows/test-v1.3.2
     needs: prerequisites
     with:
       project:            ${{ github.event.inputs.project }}
       os:                 ${{ needs.prerequisites.outputs.os }}
       verbose:            ${{ fromJSON(needs.prerequisites.outputs.verbose) }}
-      dotnet_sdk_version: '6.0.200'
+      path_proj_install_project_assets: "eng/InstallProjectAssets.proj"
+      dotnet_sdk_version: '8.0.100'
+      timeout_minutes_test_job:   10
       timeout_hang:               "[ {'OS':'windows','Timeout':'6min'}, {'OS':'macos','Timeout':'3min'}, {'OS':'','Timeout':'1min'} ]"
       timeout_vstest_connection:  "[ {'OS':'windows','Timeout':360}, {'OS':'macos','Timeout':180}, {'OS':'','Timeout':60} ]"
+      extra_options_common:                   ${{ github.event.inputs.extra_options_common }}
+      dotnet_test_options_verbosity_level:    ${{ github.event.inputs.dotnet_test_options_verbosity_level }}
+      dotnet_test_options_framework:          ${{ github.event.inputs.dotnet_test_options_framework }}
+      dotnet_test_options_filter_expression:  ${{ github.event.inputs.dotnet_test_options_filter_expression }}
     secrets:
       token_repo: ${{ secrets.GITHUB_TOKEN }}

--- a/eng/BuildAllProjects.ps1
+++ b/eng/BuildAllProjects.ps1
@@ -1,0 +1,28 @@
+#!/usr/bin/env pwsh
+# SPDX-FileCopyrightText: 2022 smdn <smdn@smdn.jp>
+# SPDX-License-Identifier: MIT
+
+$RepositoryRootDirectory = [System.IO.Path]::GetFullPath(
+  [System.IO.Path]::Join($PSScriptRoot, "../")
+)
+
+# download Smdn.MSBuild.ProjectAssets.* first
+dotnet restore $([System.IO.Path]::Join($RepositoryRootDirectory, 'eng', 'InstallProjectAssets.proj'))
+
+# create a solution for the build target projects
+Set-Location $RepositoryRootDirectory
+
+dotnet new sln
+
+# add build target projects to the solution
+$ProjectFiles = Get-ChildItem -Path $([System.IO.Path]::Join($RepositoryRootDirectory, 'src', 'Smdn.*', '*')) -Filter '*.csproj'
+
+foreach ($ProjectFile in $ProjectFiles) {
+  dotnet sln add $ProjectFile
+}
+
+# restore dependencies
+dotnet restore
+
+# then build all projects
+dotnet build --no-restore

--- a/eng/InstallProjectAssets.proj
+++ b/eng/InstallProjectAssets.proj
@@ -1,0 +1,20 @@
+<!--
+SPDX-FileCopyrightText: 2022 smdn <smdn@smdn.jp>
+SPDX-License-Identifier: MIT
+-->
+<!--
+  This project file performs downloading packages defined by PackageDownload.
+  Run `dotnet restore` to download the packages.
+-->
+<Project Sdk="Microsoft.Build.NoTargets/1.0.80">
+  <Import Project="$(MSBuildThisFileDirectory)..\src\Directory.Build.props" />
+
+  <!-- ref: https://learn.microsoft.com/en-us/nuget/consume-packages/packagedownload-functionality -->
+  <PropertyGroup>
+    <NoBuild>true</NoBuild>
+    <TargetFramework>netstandard1.0</TargetFramework>
+    <AutomaticallyUseReferenceAssemblyPackages>false</AutomaticallyUseReferenceAssemblyPackages>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\src\Directory.Build.targets" />
+</Project>

--- a/eng/pack.ps1
+++ b/eng/pack.ps1
@@ -31,7 +31,10 @@ dotnet publish --configuration Release --framework $PublishTargetFramework --no-
 # create ZIP archive
 $PathToArchive = $([System.IO.Path]::Combine(${PSScriptRoot}, $PackageName + ".zip"))
 
-Remove-Item -Path $PathToArchive # remove existing file before creating archive
+if (Test-Path $PathToArchive) {
+  # remove existing file before creating archive
+  Remove-Item -Path $PathToArchive
+}
 Compress-Archive -CompressionLevel Optimal -Path ${PathToPublishOutputDirectory} -DestinationPath $PathToArchive
 
 # delete the temporary output directory

--- a/eng/pack.ps1
+++ b/eng/pack.ps1
@@ -2,12 +2,12 @@
 # SPDX-FileCopyrightText: 2022 smdn <smdn@smdn.jp>
 # SPDX-License-Identifier: MIT
 
-$PublishTargetFramework = 'netcoreapp3.1'
+$PublishTargetFramework = 'net8.0'
 $PathToProjectToGetVersion = $([System.IO.Path]::Combine(${PSScriptRoot}, '../src/Smdn.HatenaBlogTools.Cli.Login/Smdn.HatenaBlogTools.Cli.Login.csproj'))
 
 # get CLI version
-dotnet build --framework net6.0 $PathToProjectToGetVersion
-$InformationalVersion = dotnet run --no-build --framework net6.0 --project $PathToProjectToGetVersion -- --version
+dotnet build --framework net8.0 $PathToProjectToGetVersion
+$InformationalVersion = dotnet run --no-build --framework net8.0 --project $PathToProjectToGetVersion -- --version
 $InformationalVersion = $InformationalVersion -replace '\(.+\)', ''
 $Version = New-Object -TypeName System.Version -ArgumentList $InformationalVersion
 

--- a/eng/pack.ps1
+++ b/eng/pack.ps1
@@ -9,6 +9,7 @@ $PathToProjectToGetVersion = $([System.IO.Path]::Combine(${PSScriptRoot}, '../sr
 dotnet build --framework net8.0 $PathToProjectToGetVersion
 $InformationalVersion = dotnet run --no-build --framework net8.0 --project $PathToProjectToGetVersion -- --version
 $InformationalVersion = $InformationalVersion -replace '\(.+\)', ''
+$InformationalVersion = $InformationalVersion -replace '\+[0-9a-z]+', ''
 $Version = New-Object -TypeName System.Version -ArgumentList $InformationalVersion
 
 # generate a temporary solution file for build CLI assemblies
@@ -20,7 +21,7 @@ dotnet new sln --name $CliSolutionName --output $PathToCliSolutionDirectory
 dotnet sln $PathToCliSolutionFile add $([System.IO.Path]::Combine(${PSScriptRoot}, '../src/Smdn.HatenaBlogTools.Cli.*/Smdn.HatenaBlogTools.Cli.*.csproj'))
 
 # determine package name and output directory
-$PackageName = "HatenaBlogTools-${Version}"
+$PackageName = "HatenaBlogTools-$($Version.Major).$($Version.Minor)"
 $PathToPublishOutputDirectory = $([System.IO.Path]::Combine(${PSScriptRoot}, $PackageName))
 
 # build and publish CLI executables

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -21,6 +21,14 @@ SPDX-License-Identifier: MIT
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 
+  <PropertyGroup Label="common project configurations">
+    <NoWarn>CA1032;$(NoWarn)</NoWarn> <!-- CA1032: Add the following constructor to XxxException -->
+    <NoWarn>CA1062;$(NoWarn)</NoWarn> <!-- CA1062: 検証パラメーターが使用前に非 null です。適切であれば、引数が null の場合に ArgumentNullException をスローします。 -->
+    <NoWarn>CS1591;$(NoWarn)</NoWarn> <!-- CS1591: Missing XML comment for publicly visible type or member 'Type_or_Member' -->
+    <NoWarn>IDE1006;$(NoWarn)</NoWarn> <!-- IDE1006: Naming rule violation: These words must begin with upper case characters: -->
+    <NoWarn>SYSLIB1045;$(NoWarn)</NoWarn> <!-- SYSLIB1045: コンパイル時に正規表現の実装を生成するには、'GeneratedRegexAttribute' を使用します。 -->
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference
       Include="Smdn.MSBuild.DefineConstants.NETSdkApi"

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -24,7 +24,7 @@ SPDX-License-Identifier: MIT
   <ItemGroup>
     <PackageReference
       Include="Smdn.MSBuild.DefineConstants.NETSdkApi"
-      Version="[1.3.6]"
+      Version="[1.4.8]"
       PrivateAssets="all"
       IncludeAssets="build"
     />

--- a/src/ProjectAssets.props
+++ b/src/ProjectAssets.props
@@ -4,8 +4,8 @@ SPDX-License-Identifier: MIT
 -->
 <Project>
   <PropertyGroup>
-    <SmdnProjectAssets_Common_PackageVersion>1.1.2</SmdnProjectAssets_Common_PackageVersion>
-    <SmdnProjectAssets_Library_PackageVersion>1.3.0</SmdnProjectAssets_Library_PackageVersion>
+    <SmdnProjectAssets_Common_PackageVersion Condition=" '$(SmdnProjectAssets_Common_PackageVersion)' == '' ">1.4.0</SmdnProjectAssets_Common_PackageVersion>
+    <SmdnProjectAssets_Library_PackageVersion Condition=" '$(SmdnProjectAssets_Library_PackageVersion)' == '' ">1.7.3</SmdnProjectAssets_Library_PackageVersion>
   </PropertyGroup>
 
   <!--

--- a/src/Smdn.HatenaBlogTools.Cli.props
+++ b/src/Smdn.HatenaBlogTools.Cli.props
@@ -5,10 +5,10 @@ SPDX-License-Identifier: MIT
 <Project>
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net47;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net47</TargetFrameworks>
     <VersionPrefix>3.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
-    <Nullable Condition=" '$(TargetFramework)' == 'net6.0' ">warnings</Nullable>
+    <Nullable Condition=" '$(TargetFramework)' == 'net8.0' ">warnings</Nullable>
   </PropertyGroup>
 
   <PropertyGroup Label="assembly attributes">

--- a/src/Smdn.HatenaBlogTools.Cli.props
+++ b/src/Smdn.HatenaBlogTools.Cli.props
@@ -8,7 +8,12 @@ SPDX-License-Identifier: MIT
     <TargetFrameworks>net8.0;net47</TargetFrameworks>
     <VersionPrefix>3.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
+    <RootNamespace/> <!-- empty the root namespace so that the namespace is determined only by the directory name, for code style rule IDE0030 -->
     <Nullable Condition=" '$(TargetFramework)' == 'net8.0' ">warnings</Nullable>
+    <NoWarn>IDE0130;$(NoWarn)</NoWarn> <!-- IDE0130: Namespace "XXX" はフォルダー構造と一致しません。 -->
+    <NoWarn>CA1502;$(NoWarn)</NoWarn> <!-- CA1502: 'XXX' のサイクロマティック複雑度は 'n' です。コードを書き換えるか、リファクタリングし、複雑度を '26' 未満に緩和します。 -->
+    <NoWarn>SA1402;$(NoWarn)</NoWarn> <!-- SA1402: File may only contain a single type -->
+    <NoWarn>SA1649;$(NoWarn)</NoWarn> <!-- SA1649: File name should match first type name -->
   </PropertyGroup>
 
   <PropertyGroup Label="assembly attributes">

--- a/src/Smdn.HatenaBlogTools.Core/Smdn.HatenaBlogTools.Core.csproj
+++ b/src/Smdn.HatenaBlogTools.Core/Smdn.HatenaBlogTools.Core.csproj
@@ -4,7 +4,7 @@ SPDX-License-Identifier: MIT
 -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net47;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net47;netstandard2.1</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <VersionPrefix>3.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>

--- a/src/Smdn.HatenaBlogTools.Core/Smdn.HatenaBlogTools.Core.csproj
+++ b/src/Smdn.HatenaBlogTools.Core/Smdn.HatenaBlogTools.Core.csproj
@@ -9,6 +9,7 @@ SPDX-License-Identifier: MIT
     <VersionPrefix>3.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Nullable>enable</Nullable>
+    <RootNamespace/> <!-- empty the root namespace so that the namespace is determined only by the directory name, for code style rule IDE0030 -->
   </PropertyGroup>
 
   <PropertyGroup Label="assembly attributes">

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -24,8 +24,8 @@ SPDX-License-Identifier: MIT
   />
 
   <ItemGroup Condition=" '$(IsTestProject)' == 'true' ">
-    <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0"/>
+    <PackageReference Include="NUnit" Version="4.2.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1"/>
   </ItemGroup>
 </Project>

--- a/tests/Smdn.HatenaBlogTools.Cli.DumpAllEntries/Smdn.HatenaBlogTools.Cli.DumpAllEntries.Tests.csproj
+++ b/tests/Smdn.HatenaBlogTools.Cli.DumpAllEntries/Smdn.HatenaBlogTools.Cli.DumpAllEntries.Tests.csproj
@@ -4,8 +4,7 @@ SPDX-License-Identifier: MIT
 -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition=" '$(EnableTargetFrameworkDotNet)' == 'true' ">net6.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(EnableTargetFrameworkNetCoreApp)' == 'true' ">$(TargetFrameworks);netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(EnableTargetFrameworkDotNet)' == 'true' ">net8.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(EnableTargetFrameworkNetFx)' == 'true' ">$(TargetFrameworks);net47</TargetFrameworks>
   </PropertyGroup>
 

--- a/tests/Smdn.HatenaBlogTools.Cli.DumpAllEntries/Smdn.HatenaBlogTools.Cli.DumpAllEntries.Tests.csproj
+++ b/tests/Smdn.HatenaBlogTools.Cli.DumpAllEntries/Smdn.HatenaBlogTools.Cli.DumpAllEntries.Tests.csproj
@@ -4,7 +4,8 @@ SPDX-License-Identifier: MIT
 -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition=" '$(EnableTargetFrameworkDotNet)' == 'true' ">net8.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(EnableTargetFrameworkDotNet80)' == 'true' ">net8.0;$(TargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(EnableTargetFrameworkDotNet60)' == 'true' ">net6.0;$(TargetFrameworks)</TargetFrameworks>
     <TargetFrameworks Condition=" '$(EnableTargetFrameworkNetFx)' == 'true' ">$(TargetFrameworks);net47</TargetFrameworks>
   </PropertyGroup>
 

--- a/tests/Smdn.HatenaBlogTools.Cli.DumpAllEntries/Smdn.HatenaBlogTools/BloggerFormatterTests.cs
+++ b/tests/Smdn.HatenaBlogTools.Cli.DumpAllEntries/Smdn.HatenaBlogTools/BloggerFormatterTests.cs
@@ -83,14 +83,14 @@ public class BloggerFormatterTests {
     // /feed/entry/published
     Assert.That(elementEntry.Element(AtomPub.Namespaces.Atom + "published"), Is.Not.Null);
     Assert.That(
-      DateTimeOffset.Parse(elementEntry.Element(AtomPub.Namespaces.Atom + "published")!.Value),
+      DateTimeOffset.Parse(elementEntry.Element(AtomPub.Namespaces.Atom + "published")!.Value, formatProvider: null),
       Is.EqualTo(entry.DatePublished)
     );
 
     // /feed/entry/updated
     Assert.That(elementEntry.Element(AtomPub.Namespaces.Atom + "published"), Is.Not.Null);
     Assert.That(
-      DateTimeOffset.Parse(elementEntry.Element(AtomPub.Namespaces.Atom + "updated")!.Value),
+      DateTimeOffset.Parse(elementEntry.Element(AtomPub.Namespaces.Atom + "updated")!.Value, formatProvider: null),
       Is.EqualTo(entry.DateUpdated)
     );
 

--- a/tests/Smdn.HatenaBlogTools.Cli.DumpAllEntries/Smdn.HatenaBlogTools/BloggerFormatterTests.cs
+++ b/tests/Smdn.HatenaBlogTools.Cli.DumpAllEntries/Smdn.HatenaBlogTools/BloggerFormatterTests.cs
@@ -37,21 +37,21 @@ public class BloggerFormatterTests {
     // /feed
     var elementFeed = doc.Root!;
 
-    Assert.AreEqual(
-      AtomPub.Namespaces.Atom + "feed",
-      elementFeed.Name
+    Assert.That(
+      elementFeed.Name,
+      Is.EqualTo(AtomPub.Namespaces.Atom + "feed")
     );
 
     // /feed/title
-    Assert.AreEqual(
-      blogTitle,
-      elementFeed.Element(AtomPub.Namespaces.Atom + "title")?.Value
+    Assert.That(
+      elementFeed.Element(AtomPub.Namespaces.Atom + "title")?.Value,
+      Is.EqualTo(blogTitle)
     );
 
     // /feed/generator
-    Assert.AreEqual(
-      "Blogger",
-      elementFeed.Element(AtomPub.Namespaces.Atom + "generator")?.Value
+    Assert.That(
+      elementFeed.Element(AtomPub.Namespaces.Atom + "generator")?.Value,
+      Is.EqualTo("Blogger")
     );
 
     // /feed/entry
@@ -61,56 +61,56 @@ public class BloggerFormatterTests {
         e.Element(AtomPub.Namespaces.Atom + "category")?.HasAttributeWithValue("term", "http://schemas.google.com/blogger/2008/kind#post") ?? false
       ).ToList();
 
-    Assert.AreEqual(
-      1,
-      elementsEntryOfPost.Count
+    Assert.That(
+      elementsEntryOfPost.Count,
+      Is.EqualTo(1)
     );
 
     var elementEntry = elementsEntryOfPost.First();
 
     // /feed/entry/id
-    Assert.AreEqual(
-      entry.Id!.AbsoluteUri,
-      elementEntry.Element(AtomPub.Namespaces.Atom + "id")?.Value
+    Assert.That(
+      elementEntry.Element(AtomPub.Namespaces.Atom + "id")?.Value,
+      Is.EqualTo(entry.Id!.AbsoluteUri)
     );
 
     // /feed/entry/author
-    CollectionAssert.AreEquivalent(
-      entry.Authors,
-      elementEntry.Elements(AtomPub.Namespaces.Atom + "author").Elements(AtomPub.Namespaces.Atom + "name").Select(e => e.Value)
+    Assert.That(
+      elementEntry.Elements(AtomPub.Namespaces.Atom + "author").Elements(AtomPub.Namespaces.Atom + "name").Select(e => e.Value),
+      Is.EquivalentTo(entry.Authors)
     );
 
     // /feed/entry/published
-    Assert.IsNotNull(elementEntry.Element(AtomPub.Namespaces.Atom + "published"));
-    Assert.AreEqual(
-      entry.DatePublished,
-      DateTimeOffset.Parse(elementEntry.Element(AtomPub.Namespaces.Atom + "published")!.Value)
+    Assert.That(elementEntry.Element(AtomPub.Namespaces.Atom + "published"), Is.Not.Null);
+    Assert.That(
+      DateTimeOffset.Parse(elementEntry.Element(AtomPub.Namespaces.Atom + "published")!.Value),
+      Is.EqualTo(entry.DatePublished)
     );
 
     // /feed/entry/updated
-    Assert.IsNotNull(elementEntry.Element(AtomPub.Namespaces.Atom + "published"));
-    Assert.AreEqual(
-      entry.DateUpdated,
-      DateTimeOffset.Parse(elementEntry.Element(AtomPub.Namespaces.Atom + "updated")!.Value)
+    Assert.That(elementEntry.Element(AtomPub.Namespaces.Atom + "published"), Is.Not.Null);
+    Assert.That(
+      DateTimeOffset.Parse(elementEntry.Element(AtomPub.Namespaces.Atom + "updated")!.Value),
+      Is.EqualTo(entry.DateUpdated)
     );
 
     // /feed/entry/title
-    Assert.IsNotNull(elementEntry.Element(AtomPub.Namespaces.Atom + "title"));
-    Assert.AreEqual(
-      entry.Title,
-      elementEntry.Element(AtomPub.Namespaces.Atom + "title")!.Value
+    Assert.That(elementEntry.Element(AtomPub.Namespaces.Atom + "title"), Is.Not.Null);
+    Assert.That(
+      elementEntry.Element(AtomPub.Namespaces.Atom + "title")!.Value,
+      Is.EqualTo(entry.Title)
     );
 
     // /feed/entry/app:control/app:draft
-    Assert.IsNull(elementEntry.Element(AtomPub.Namespaces.App + "control"));
+    Assert.That(elementEntry.Element(AtomPub.Namespaces.App + "control"), Is.Null);
 
     // /feed/entry/category
-    Assert.AreEqual(
-      "http://schemas.google.com/blogger/2008/kind#post",
+    Assert.That(
       elementEntry
         .Elements(AtomPub.Namespaces.Atom + "category")
         .FirstOrDefault(e => e.HasAttributeWithValue("scheme", "http://schemas.google.com/g/2005#kind"))
-        ?.GetAttributeValue("term")
+        ?.GetAttributeValue("term"),
+      Is.EqualTo("http://schemas.google.com/blogger/2008/kind#post")
     );
 
     var categories = elementEntry
@@ -118,20 +118,20 @@ public class BloggerFormatterTests {
       .Where(e => e.HasAttributeWithValue("scheme", "http://www.blogger.com/atom/ns#"))
       .Select(e => e.GetAttributeValue("term"));
 
-    CollectionAssert.AreEquivalent(
-      entry.Categories,
-      categories
+    Assert.That(
+      categories,
+      Is.EquivalentTo(entry.Categories)
     );
 
     // /feed/entry/content
-    Assert.AreEqual(
-      "html",
-      elementEntry.Element(AtomPub.Namespaces.Atom + "content")?.GetAttributeValue("type")
+    Assert.That(
+      elementEntry.Element(AtomPub.Namespaces.Atom + "content")?.GetAttributeValue("type"),
+      Is.EqualTo("html")
     );
 
-    Assert.AreEqual(
-      entry.FormattedContent,
-      elementEntry.Element(AtomPub.Namespaces.Atom + "content")?.Value
+    Assert.That(
+      elementEntry.Element(AtomPub.Namespaces.Atom + "content")?.Value,
+      Is.EqualTo(entry.FormattedContent)
     );
   }
 
@@ -158,11 +158,11 @@ public class BloggerFormatterTests {
       );
 
     // /feed/entry/app:control/app:draft
-    Assert.IsNotNull(elementEntry.Element(AtomPub.Namespaces.App + "control"));
-    Assert.IsNotNull(elementEntry.Element(AtomPub.Namespaces.App + "control")!.Element(AtomPub.Namespaces.App + "draft"));
-    Assert.AreEqual(
-      "yes",
-      elementEntry.Element(AtomPub.Namespaces.App + "control")!.Element(AtomPub.Namespaces.App + "draft")!.Value
+    Assert.That(elementEntry.Element(AtomPub.Namespaces.App + "control"), Is.Not.Null);
+    Assert.That(elementEntry.Element(AtomPub.Namespaces.App + "control")!.Element(AtomPub.Namespaces.App + "draft"), Is.Not.Null);
+    Assert.That(
+      elementEntry.Element(AtomPub.Namespaces.App + "control")!.Element(AtomPub.Namespaces.App + "draft")!.Value,
+      Is.EqualTo("yes")
     );
   }
 
@@ -197,25 +197,25 @@ public class BloggerFormatterTests {
       )
       .ToList();
 
-    Assert.AreEqual(2, elementListEntries.Count);
+    Assert.That(elementListEntries.Count, Is.EqualTo(2));
 
     for (var index = 0; index < entries.Length; index++) {
       // /feed/entry[index]/id
-      Assert.AreEqual(
-        entries[index].Id!.AbsoluteUri,
-        elementListEntries[index].Element(AtomPub.Namespaces.Atom + "id")?.Value
+      Assert.That(
+        elementListEntries[index].Element(AtomPub.Namespaces.Atom + "id")?.Value,
+        Is.EqualTo(entries[index].Id!.AbsoluteUri)
       );
 
       // /feed/entry[index]/title
-      Assert.AreEqual(
-        entries[index].Title,
-        elementListEntries[index].Element(AtomPub.Namespaces.Atom + "title")?.Value
+      Assert.That(
+        elementListEntries[index].Element(AtomPub.Namespaces.Atom + "title")?.Value,
+        Is.EqualTo(entries[index].Title)
       );
 
       // /feed/entry[index]/title
-      Assert.AreEqual(
-        entries[index].FormattedContent,
-        elementListEntries[index].Element(AtomPub.Namespaces.Atom + "content")?.Value
+      Assert.That(
+        elementListEntries[index].Element(AtomPub.Namespaces.Atom + "content")?.Value,
+        Is.EqualTo(entries[index].FormattedContent)
       );
     }
   }

--- a/tests/Smdn.HatenaBlogTools.Cli.DumpAllEntries/Smdn.HatenaBlogTools/HatenaDiaryFormatterTests.cs
+++ b/tests/Smdn.HatenaBlogTools.Cli.DumpAllEntries/Smdn.HatenaBlogTools/HatenaDiaryFormatterTests.cs
@@ -119,7 +119,7 @@ public class HatenaDiaryFormatterTests {
 
     var day = doc.Root!.Element("day")!;
 
-    Assert.That(day.Attribute("date")?.Value, Is.EqualTo(dateUpdated.LocalDateTime.ToString("yyyy-MM-dd")));
+    Assert.That(day.Attribute("date")?.Value, Is.EqualTo(dateUpdated.LocalDateTime.ToString("yyyy-MM-dd", provider: null)));
     Assert.That(day.Attribute("title")?.Value, Is.Empty);
 
     // /diary/day/body
@@ -172,7 +172,7 @@ public class HatenaDiaryFormatterTests {
     var doc = XDocument.Load(new HatenaDiaryFormatter().ToStream(entries));
 
     var day = doc.Root!.Elements("day").First(
-      e => string.Equals(dateUpdatedEntry0.LocalDateTime.ToString("yyyy-MM-dd"), e.Attribute("date")?.Value, StringComparison.Ordinal)
+      e => string.Equals(dateUpdatedEntry0.LocalDateTime.ToString("yyyy-MM-dd", provider: null), e.Attribute("date")?.Value, StringComparison.Ordinal)
     );
     var bodyText = day.Value;
 
@@ -211,13 +211,13 @@ public class HatenaDiaryFormatterTests {
     var doc = XDocument.Load(new HatenaDiaryFormatter().ToStream(entries));
 
     var firstDay = doc.Root!.Elements("day").First(
-      e => string.Equals(dateUpdatedEntry0.LocalDateTime.ToString("yyyy-MM-dd"), e.Attribute("date")?.Value, StringComparison.Ordinal)
+      e => string.Equals(dateUpdatedEntry0.LocalDateTime.ToString("yyyy-MM-dd", provider: null), e.Attribute("date")?.Value, StringComparison.Ordinal)
     );
 
     Assert.That(firstDay.Element("body")!.Value.Replace("\r", string.Empty), Does.Contain($"*{dateUpdatedEntry0.ToUnixTimeSeconds():D}*entry0\nentry0-content\n"));
 
     var secondDay = doc.Root!.Elements("day").First(
-      e => string.Equals(dateUpdatedEntry1.LocalDateTime.ToString("yyyy-MM-dd"), e.Attribute("date")?.Value, StringComparison.Ordinal)
+      e => string.Equals(dateUpdatedEntry1.LocalDateTime.ToString("yyyy-MM-dd", provider: null), e.Attribute("date")?.Value, StringComparison.Ordinal)
     );
 
     Assert.That(secondDay.Element("body")!.Value.Replace("\r", string.Empty), Does.Contain($"*{dateUpdatedEntry1.ToUnixTimeSeconds():D}*entry1\nentry1-content\n"));

--- a/tests/Smdn.HatenaBlogTools.Cli.DumpAllEntries/Smdn.HatenaBlogTools/HatenaDiaryFormatterTests.cs
+++ b/tests/Smdn.HatenaBlogTools.Cli.DumpAllEntries/Smdn.HatenaBlogTools/HatenaDiaryFormatterTests.cs
@@ -70,16 +70,16 @@ public class HatenaDiaryFormatterTests {
     var doc = XDocument.Load(formatter.ToStream(new[] { entry }));
     var day = doc.Root!.Element("day")!;
 
-    Assert.AreEqual(expectedDateString, day.Attribute("date")?.Value);
+    Assert.That(day.Attribute("date")?.Value, Is.EqualTo(expectedDateString));
 
     var body = day.Element("body")!;
     var bodyLines = new StringReader(body.Value).ReadAllLines();
     var firstLine = bodyLines.FirstOrDefault();
 
-    Assert.IsNotNull(firstLine);
-    Assert.AreEqual(
-      $"*{dateUpdated.ToUnixTimeSeconds():D}*entry0",
-      firstLine
+    Assert.That(firstLine, Is.Not.Null);
+    Assert.That(
+      firstLine,
+      Is.EqualTo($"*{dateUpdated.ToUnixTimeSeconds():D}*entry0")
     );
   }
 
@@ -112,32 +112,32 @@ public class HatenaDiaryFormatterTests {
     var doc = XDocument.Load(new HatenaDiaryFormatter().ToStream(new[] { entry }));
 
     // /diary
-    Assert.AreEqual("diary", doc.Root!.Name.LocalName);
+    Assert.That(doc.Root!.Name.LocalName, Is.EqualTo("diary"));
 
     // /diary/day
-    Assert.AreEqual(1, doc.Root!.Elements("day").Count());
+    Assert.That(doc.Root!.Elements("day").Count(), Is.EqualTo(1));
 
     var day = doc.Root!.Element("day")!;
 
-    Assert.AreEqual(dateUpdated.LocalDateTime.ToString("yyyy-MM-dd"), day.Attribute("date")?.Value);
-    Assert.IsEmpty(day.Attribute("title")?.Value);
+    Assert.That(day.Attribute("date")?.Value, Is.EqualTo(dateUpdated.LocalDateTime.ToString("yyyy-MM-dd")));
+    Assert.That(day.Attribute("title")?.Value, Is.Empty);
 
     // /diary/day/body
-    Assert.AreEqual(1, day.Elements("body").Count());
+    Assert.That(day.Elements("body").Count(), Is.EqualTo(1));
 
     var body = day.Element("body")!;
     var bodyLines = new StringReader(body.Value).ReadAllLines();
     var firstLine = bodyLines.FirstOrDefault();
 
-    Assert.IsNotNull(firstLine);
-    Assert.AreEqual(
-      $"*{dateUpdated.ToUnixTimeSeconds():D}*[entry0-category0][entry0-category1][entry0-category2]entry0",
-      firstLine
+    Assert.That(firstLine, Is.Not.Null);
+    Assert.That(
+      firstLine,
+      Is.EqualTo($"*{dateUpdated.ToUnixTimeSeconds():D}*[entry0-category0][entry0-category1][entry0-category2]entry0")
     );
 
-    StringAssert.StartsWith(
-      entry.Content,
-      string.Join("\n", bodyLines.Skip(1))
+    Assert.That(
+      string.Join("\n", bodyLines.Skip(1)),
+      Does.StartWith(entry.Content)
     );
   }
 
@@ -176,8 +176,8 @@ public class HatenaDiaryFormatterTests {
     );
     var bodyText = day.Value;
 
-    StringAssert.Contains($"*{dateUpdatedEntry0.ToUnixTimeSeconds():D}*entry0\nentry0-content", bodyText.Replace("\r", string.Empty));
-    StringAssert.Contains($"*{dateUpdatedEntry1.ToUnixTimeSeconds():D}*entry1\nentry1-content", bodyText.Replace("\r", string.Empty));
+    Assert.That(bodyText.Replace("\r", string.Empty), Does.Contain($"*{dateUpdatedEntry0.ToUnixTimeSeconds():D}*entry0\nentry0-content"));
+    Assert.That(bodyText.Replace("\r", string.Empty), Does.Contain($"*{dateUpdatedEntry1.ToUnixTimeSeconds():D}*entry1\nentry1-content"));
   }
 
   private static System.Collections.IEnumerable YieldTestCases_TestFormat_MultipleEntries_DifferentDate()
@@ -214,12 +214,12 @@ public class HatenaDiaryFormatterTests {
       e => string.Equals(dateUpdatedEntry0.LocalDateTime.ToString("yyyy-MM-dd"), e.Attribute("date")?.Value, StringComparison.Ordinal)
     );
 
-    StringAssert.Contains($"*{dateUpdatedEntry0.ToUnixTimeSeconds():D}*entry0\nentry0-content\n", firstDay.Element("body")!.Value.Replace("\r", string.Empty));
+    Assert.That(firstDay.Element("body")!.Value.Replace("\r", string.Empty), Does.Contain($"*{dateUpdatedEntry0.ToUnixTimeSeconds():D}*entry0\nentry0-content\n"));
 
     var secondDay = doc.Root!.Elements("day").First(
       e => string.Equals(dateUpdatedEntry1.LocalDateTime.ToString("yyyy-MM-dd"), e.Attribute("date")?.Value, StringComparison.Ordinal)
     );
 
-    StringAssert.Contains($"*{dateUpdatedEntry1.ToUnixTimeSeconds():D}*entry1\nentry1-content\n", secondDay.Element("body")!.Value.Replace("\r", string.Empty));
+    Assert.That(secondDay.Element("body")!.Value.Replace("\r", string.Empty), Does.Contain($"*{dateUpdatedEntry1.ToUnixTimeSeconds():D}*entry1\nentry1-content\n"));
   }
 }

--- a/tests/Smdn.HatenaBlogTools.Cli.DumpAllEntries/Smdn.HatenaBlogTools/MovableTypeFormatterTests.cs
+++ b/tests/Smdn.HatenaBlogTools.Cli.DumpAllEntries/Smdn.HatenaBlogTools/MovableTypeFormatterTests.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/tests/Smdn.HatenaBlogTools.Cli.DumpAllEntries/Smdn.HatenaBlogTools/MovableTypeFormatterTests.cs
+++ b/tests/Smdn.HatenaBlogTools.Cli.DumpAllEntries/Smdn.HatenaBlogTools/MovableTypeFormatterTests.cs
@@ -24,7 +24,7 @@ public class MovableTypeFormatterTests {
 
   [TestCaseSource(nameof(YieldTestCases_TestToDateString_DateTime))]
   public void TestToDateString_DateTime(DateTime dateTime, string expected)
-    => Assert.AreEqual(expected, MovableTypeFormatter.ToDateString(dateTime));
+    => Assert.That(MovableTypeFormatter.ToDateString(dateTime), Is.EqualTo(expected));
 
   private static System.Collections.IEnumerable YieldTestCases_TestToDateString_DateTimeOffset()
   {
@@ -43,7 +43,7 @@ public class MovableTypeFormatterTests {
 
   [TestCaseSource(nameof(YieldTestCases_TestToDateString_DateTimeOffset))]
   public void TestToDateString_DateTimeOffset(DateTimeOffset dateTimeOffset, string expected)
-    => Assert.AreEqual(expected, MovableTypeFormatter.ToDateString(dateTimeOffset));
+    => Assert.That(MovableTypeFormatter.ToDateString(dateTimeOffset), Is.EqualTo(expected));
 
   private static void Format(
     IEnumerable<PostedEntry> entries,
@@ -135,9 +135,9 @@ public class MovableTypeFormatterTests {
 
     Format(new[] { entry }, TimeZoneInfo.FindSystemTimeZoneById(timeZoneId), out var formattedText, out var _);
 
-    StringAssert.Contains(
-      "DATE: " + expectedDateString,
-      formattedText
+    Assert.That(
+      formattedText,
+      Does.Contain("DATE: " + expectedDateString)
     );
   }
 
@@ -184,9 +184,9 @@ entry0-formatted-content
 
     Format(new[] { entry }, null, out var formattedText, out var _);
 
-    Assert.AreEqual(
-      expectedResult.Replace("\r", string.Empty),
-      formattedText
+    Assert.That(
+      formattedText,
+      Is.EqualTo(expectedResult.Replace("\r", string.Empty))
     );
   }
 
@@ -233,9 +233,9 @@ entry1-formatted-content
 
     Format(entries, null, out var formattedText, out var _);
 
-    Assert.AreEqual(
-      expectedResult.Replace("\r", string.Empty),
-      formattedText.Replace(" \n", "\n") // trim line endings
+    Assert.That(
+      formattedText.Replace(" \n", "\n"),
+      Is.EqualTo(expectedResult.Replace("\r", string.Empty)) // trim line endings
     );
   }
 }

--- a/tests/Smdn.HatenaBlogTools.Cli.FixMixedContent/Smdn.HatenaBlogTools.Cli.FixMixedContent.Tests.csproj
+++ b/tests/Smdn.HatenaBlogTools.Cli.FixMixedContent/Smdn.HatenaBlogTools.Cli.FixMixedContent.Tests.csproj
@@ -4,7 +4,8 @@ SPDX-License-Identifier: MIT
 -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition=" '$(EnableTargetFrameworkDotNet)' == 'true' ">net8.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(EnableTargetFrameworkDotNet80)' == 'true' ">net8.0;$(TargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(EnableTargetFrameworkDotNet60)' == 'true' ">net6.0;$(TargetFrameworks)</TargetFrameworks>
     <TargetFrameworks Condition=" '$(EnableTargetFrameworkNetFx)' == 'true' ">$(TargetFrameworks);net47</TargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/tests/Smdn.HatenaBlogTools.Cli.FixMixedContent/Smdn.HatenaBlogTools.Cli.FixMixedContent.Tests.csproj
+++ b/tests/Smdn.HatenaBlogTools.Cli.FixMixedContent/Smdn.HatenaBlogTools.Cli.FixMixedContent.Tests.csproj
@@ -4,8 +4,7 @@ SPDX-License-Identifier: MIT
 -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition=" '$(EnableTargetFrameworkDotNet)' == 'true' ">net6.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(EnableTargetFrameworkNetCoreApp)' == 'true' ">$(TargetFrameworks);netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(EnableTargetFrameworkDotNet)' == 'true' ">net8.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(EnableTargetFrameworkNetFx)' == 'true' ">$(TargetFrameworks);net47</TargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/tests/Smdn.HatenaBlogTools.Cli.FixMixedContent/Smdn.HatenaBlogTools/Tests.cs
+++ b/tests/Smdn.HatenaBlogTools.Cli.FixMixedContent/Smdn.HatenaBlogTools/Tests.cs
@@ -73,7 +73,7 @@ http://example.com/
 
     var output = EditLocalContent(input, null);
 
-    Assert.AreEqual(expectedOutput, output);
+    Assert.That(output, Is.EqualTo(expectedOutput));
   }
 
   [Test]
@@ -106,7 +106,7 @@ http://example.net/
 
     var output = EditLocalContent(input, new[] { "--fix-blog-url", "--custom-domain", "example.com" });
 
-    Assert.AreEqual(expectedOutput, output);
+    Assert.That(output, Is.EqualTo(expectedOutput));
   }
 
   [Test]
@@ -135,7 +135,7 @@ http://example.net/
 
     var output = EditLocalContent(input, new[] { "--fix-mixed-content" });
 
-    Assert.AreEqual(expectedOutput, output);
+    Assert.That(output, Is.EqualTo(expectedOutput));
   }
 
   [Test]
@@ -154,7 +154,7 @@ http://example.net/
 
     var output = EditLocalContent(input, new[] { "--fix-mixed-content", "--include-domain", "example.com", "--include-domain", "example.net" });
 
-    Assert.AreEqual(expectedOutput, output);
+    Assert.That(output, Is.EqualTo(expectedOutput));
   }
 
   [Test]
@@ -173,7 +173,7 @@ http://example.net/
 
     var output = EditLocalContent(input, new[] { "--fix-mixed-content", "--exclude-domain", "example.com", "--exclude-domain", "example.net" });
 
-    Assert.AreEqual(expectedOutput, output);
+    Assert.That(output, Is.EqualTo(expectedOutput));
   }
 
   [Test]
@@ -202,7 +202,7 @@ http://example.net/
 
     var output = EditLocalContent(input, new[] { "--fix-mixed-content", "--fix-blog-url", "--custom-domain", "example.com" });
 
-    Assert.AreEqual(expectedOutput, output);
+    Assert.That(output, Is.EqualTo(expectedOutput));
   }
 
   [Test]
@@ -227,7 +227,7 @@ http://example.net/
 
     var output = EditLocalContent(input, new[] { "--fix-mixed-content" });
 
-    Assert.AreEqual(expectedOutput, output);
+    Assert.That(output, Is.EqualTo(expectedOutput));
   }
 
   [Test]
@@ -252,6 +252,6 @@ http://example.net/
 
     var output = EditLocalContent(input, new[] { "--fix-blog-url", "--custom-domain", "smdn.hatenablog.jp" });
 
-    Assert.AreEqual(expectedOutput, output);
+    Assert.That(output, Is.EqualTo(expectedOutput));
   }
 }

--- a/tests/Smdn.HatenaBlogTools.Cli.ReplaceContentText/Smdn.HatenaBlogTools.Cli.ReplaceContentText.Tests.csproj
+++ b/tests/Smdn.HatenaBlogTools.Cli.ReplaceContentText/Smdn.HatenaBlogTools.Cli.ReplaceContentText.Tests.csproj
@@ -4,8 +4,7 @@ SPDX-License-Identifier: MIT
 -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition=" '$(EnableTargetFrameworkDotNet)' == 'true' ">net6.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(EnableTargetFrameworkNetCoreApp)' == 'true' ">$(TargetFrameworks);netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(EnableTargetFrameworkDotNet)' == 'true' ">net8.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(EnableTargetFrameworkNetFx)' == 'true' ">$(TargetFrameworks);net47</TargetFrameworks>
   </PropertyGroup>
 

--- a/tests/Smdn.HatenaBlogTools.Cli.ReplaceContentText/Smdn.HatenaBlogTools.Cli.ReplaceContentText.Tests.csproj
+++ b/tests/Smdn.HatenaBlogTools.Cli.ReplaceContentText/Smdn.HatenaBlogTools.Cli.ReplaceContentText.Tests.csproj
@@ -4,7 +4,8 @@ SPDX-License-Identifier: MIT
 -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition=" '$(EnableTargetFrameworkDotNet)' == 'true' ">net8.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(EnableTargetFrameworkDotNet80)' == 'true' ">net8.0;$(TargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(EnableTargetFrameworkDotNet60)' == 'true' ">net6.0;$(TargetFrameworks)</TargetFrameworks>
     <TargetFrameworks Condition=" '$(EnableTargetFrameworkNetFx)' == 'true' ">$(TargetFrameworks);net47</TargetFrameworks>
   </PropertyGroup>
 

--- a/tests/Smdn.HatenaBlogTools.Cli.ReplaceContentText/Smdn.HatenaBlogTools.HatenaBlog/PseudoHatenaBlogAtomPubClient.cs
+++ b/tests/Smdn.HatenaBlogTools.Cli.ReplaceContentText/Smdn.HatenaBlogTools.HatenaBlog/PseudoHatenaBlogAtomPubClient.cs
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2013 smdn <smdn@smdn.jp>
 // SPDX-License-Identifier: MIT
+#nullable enable
 
 using System;
 using System.Collections.Generic;

--- a/tests/Smdn.HatenaBlogTools.Cli.ReplaceContentText/Smdn.HatenaBlogTools/Tests.cs
+++ b/tests/Smdn.HatenaBlogTools.Cli.ReplaceContentText/Smdn.HatenaBlogTools/Tests.cs
@@ -44,9 +44,9 @@ public class ReplaceContentTextTests {
       out var modifiedEntries
     );
 
-    Assert.AreEqual(1, modifiedEntries.Count);
-    Assert.AreEqual("barbar", modifiedEntries[0].Content);
-    Assert.AreEqual("foobar", modifiedEntries[0].Title);
+    Assert.That(modifiedEntries.Count, Is.EqualTo(1));
+    Assert.That(modifiedEntries[0].Content, Is.EqualTo("barbar"));
+    Assert.That(modifiedEntries[0].Title, Is.EqualTo("foobar"));
   }
 
   [Test]
@@ -64,10 +64,10 @@ public class ReplaceContentTextTests {
       out var modifiedEntries
     );
 
-    Assert.AreEqual(0, modifiedEntries.Count);
+    Assert.That(modifiedEntries.Count, Is.EqualTo(0));
 
-    Assert.AreEqual("foobar", entries[0].Content);
-    Assert.AreEqual("foobar", entries[0].Title);
+    Assert.That(entries[0].Content, Is.EqualTo("foobar"));
+    Assert.That(entries[0].Title, Is.EqualTo("foobar"));
   }
 
   [Test]
@@ -85,9 +85,9 @@ public class ReplaceContentTextTests {
       out var modifiedEntries
     );
 
-    Assert.AreEqual(1, modifiedEntries.Count);
-    Assert.AreEqual("barbar", modifiedEntries[0].Content);
-    Assert.AreEqual("foobar", modifiedEntries[0].Title);
+    Assert.That(modifiedEntries.Count, Is.EqualTo(1));
+    Assert.That(modifiedEntries[0].Content, Is.EqualTo("barbar"));
+    Assert.That(modifiedEntries[0].Title, Is.EqualTo("foobar"));
   }
 
   [Test]
@@ -105,10 +105,10 @@ public class ReplaceContentTextTests {
       out var modifiedEntries
     );
 
-    Assert.AreEqual(0, modifiedEntries.Count);
+    Assert.That(modifiedEntries.Count, Is.EqualTo(0));
 
-    Assert.AreEqual("foobar", entries[0].Content);
-    Assert.AreEqual("foobar", entries[0].Title);
+    Assert.That(entries[0].Content, Is.EqualTo("foobar"));
+    Assert.That(entries[0].Title, Is.EqualTo("foobar"));
   }
 
   [Test]
@@ -126,9 +126,9 @@ public class ReplaceContentTextTests {
       out var modifiedEntries
     );
 
-    Assert.AreEqual(1, modifiedEntries.Count);
-    Assert.AreEqual("f<oo>bar", modifiedEntries[0].Content);
-    Assert.AreEqual("foobar", modifiedEntries[0].Title);
+    Assert.That(modifiedEntries.Count, Is.EqualTo(1));
+    Assert.That(modifiedEntries[0].Content, Is.EqualTo("f<oo>bar"));
+    Assert.That(modifiedEntries[0].Title, Is.EqualTo("foobar"));
   }
 
 
@@ -149,9 +149,9 @@ public class ReplaceContentTextTests {
       out var modifiedEntries
     );
 
-    Assert.AreEqual(1, modifiedEntries.Count);
-    Assert.AreEqual("foobar", modifiedEntries[0].Content);
-    Assert.AreEqual("barbar", modifiedEntries[0].Title);
+    Assert.That(modifiedEntries.Count, Is.EqualTo(1));
+    Assert.That(modifiedEntries[0].Content, Is.EqualTo("foobar"));
+    Assert.That(modifiedEntries[0].Title, Is.EqualTo("barbar"));
   }
 
   [Test]
@@ -169,10 +169,10 @@ public class ReplaceContentTextTests {
       out var modifiedEntries
     );
 
-    Assert.AreEqual(0, modifiedEntries.Count);
+    Assert.That(modifiedEntries.Count, Is.EqualTo(0));
 
-    Assert.AreEqual("foobar", entries[0].Content);
-    Assert.AreEqual("foobar", entries[0].Title);
+    Assert.That(entries[0].Content, Is.EqualTo("foobar"));
+    Assert.That(entries[0].Title, Is.EqualTo("foobar"));
   }
 
   [Test]
@@ -190,9 +190,9 @@ public class ReplaceContentTextTests {
       out var modifiedEntries
     );
 
-    Assert.AreEqual(1, modifiedEntries.Count);
-    Assert.AreEqual("foobar", modifiedEntries[0].Content);
-    Assert.AreEqual("barbar", modifiedEntries[0].Title);
+    Assert.That(modifiedEntries.Count, Is.EqualTo(1));
+    Assert.That(modifiedEntries[0].Content, Is.EqualTo("foobar"));
+    Assert.That(modifiedEntries[0].Title, Is.EqualTo("barbar"));
   }
 
   [Test]
@@ -210,9 +210,9 @@ public class ReplaceContentTextTests {
       out var modifiedEntries
     );
 
-    Assert.AreEqual(0, modifiedEntries.Count);
+    Assert.That(modifiedEntries.Count, Is.EqualTo(0));
 
-    Assert.AreEqual("foobar", entries[0].Content);
-    Assert.AreEqual("foobar", entries[0].Title);
+    Assert.That(entries[0].Content, Is.EqualTo("foobar"));
+    Assert.That(entries[0].Title, Is.EqualTo("foobar"));
   }
 }

--- a/tests/Smdn.HatenaBlogTools.Core/Smdn.HatenaBlogTools.AtomPublishingProtocol/AtomPubClient.cs
+++ b/tests/Smdn.HatenaBlogTools.Core/Smdn.HatenaBlogTools.AtomPublishingProtocol/AtomPubClient.cs
@@ -78,25 +78,25 @@ public class AtomPubClientTests {
 
     Assert.DoesNotThrow(() => status = client.Get(server.Url, out responseDocument));
 
-    Assert.AreEqual(HttpStatusCode.OK, status);
-    Assert.IsNotNull(responseDocument, nameof(responseDocument));
-    Assert.AreEqual("service", responseDocument!.Root!.Name.LocalName);
-    Assert.AreEqual(AtomPub.Namespaces.App.NamespaceName, responseDocument.Root!.Name.NamespaceName);
+    Assert.That(status, Is.EqualTo(HttpStatusCode.OK));
+    Assert.That(responseDocument, Is.Not.Null, nameof(responseDocument));
+    Assert.That(responseDocument!.Root!.Name.LocalName, Is.EqualTo("service"));
+    Assert.That(responseDocument.Root!.Name.NamespaceName, Is.EqualTo(AtomPub.Namespaces.App.NamespaceName));
 
     var (request, _) = await task;
 
-    Assert.AreEqual(WebRequestMethods.Http.Get, request.HttpMethod, nameof(request.HttpMethod));
-    Assert.AreEqual(userAgent ?? string.Empty, request.UserAgent ?? string.Empty, nameof(request.UserAgent));
-    Assert.IsNotNull(request.Headers["X-WSSE"], "has X-WSSE header");
-    StringAssert.Contains($"UsernameToken Username=\"{userName}\"", request.Headers["X-WSSE"], "X-WSSE header value");
+    Assert.That(request.HttpMethod, Is.EqualTo(WebRequestMethods.Http.Get), nameof(request.HttpMethod));
+    Assert.That(request.UserAgent ?? string.Empty, Is.EqualTo(userAgent ?? string.Empty), nameof(request.UserAgent));
+    Assert.That(request.Headers["X-WSSE"], Is.Not.Null, "has X-WSSE header");
+    Assert.That(request.Headers["X-WSSE"], Does.Contain($"UsernameToken Username=\"{userName}\""), "X-WSSE header value");
 
     var trimmedAcceptTypes = request.AcceptTypes?.Select(static t => t?.Trim())?.ToList();
 
-    CollectionAssert.Contains(trimmedAcceptTypes, "application/x.atom+xml");
-    CollectionAssert.Contains(trimmedAcceptTypes, "application/atom+xml");
-    CollectionAssert.Contains(trimmedAcceptTypes, "application/atomsvc+xml");
-    CollectionAssert.Contains(trimmedAcceptTypes, "application/xml");
-    CollectionAssert.Contains(trimmedAcceptTypes, "text/xml");
+    Assert.That(trimmedAcceptTypes, Has.Member("application/x.atom+xml"));
+    Assert.That(trimmedAcceptTypes, Has.Member("application/atom+xml"));
+    Assert.That(trimmedAcceptTypes, Has.Member("application/atomsvc+xml"));
+    Assert.That(trimmedAcceptTypes, Has.Member("application/xml"));
+    Assert.That(trimmedAcceptTypes, Has.Member("text/xml"));
   }
 
   [Test]
@@ -120,14 +120,14 @@ public class AtomPubClientTests {
 
     Assert.DoesNotThrow(() => status = client.Get(server.Url, out responseDocument));
 
-    Assert.AreEqual(HttpStatusCode.BadRequest, status);
-    Assert.IsNull(responseDocument, nameof(responseDocument));
+    Assert.That(status, Is.EqualTo(HttpStatusCode.BadRequest));
+    Assert.That(responseDocument, Is.Null, nameof(responseDocument));
 
     var (request, _) = await task;
 
-    Assert.AreEqual(WebRequestMethods.Http.Get, request.HttpMethod, nameof(request.HttpMethod));
-    Assert.IsNotNull(request.Headers["X-WSSE"], "has X-WSSE header");
-    StringAssert.Contains($"UsernameToken Username=\"{userName}\"", request.Headers["X-WSSE"], "X-WSSE header value");
+    Assert.That(request.HttpMethod, Is.EqualTo(WebRequestMethods.Http.Get), nameof(request.HttpMethod));
+    Assert.That(request.Headers["X-WSSE"], Is.Not.Null, "has X-WSSE header");
+    Assert.That(request.Headers["X-WSSE"], Does.Contain($"UsernameToken Username=\"{userName}\""), "X-WSSE header value");
   }
 
   [Test]
@@ -159,15 +159,15 @@ public class AtomPubClientTests {
       );
     });
 
-    Assert.AreEqual(HttpStatusCode.Created, status);
-    Assert.IsNotNull(responseDocument, nameof(responseDocument));
-    Assert.AreEqual("entry", responseDocument!.Root!.Name.LocalName);
-    Assert.AreEqual(AtomPub.Namespaces.Atom.NamespaceName, responseDocument.Root!.Name.NamespaceName);
+    Assert.That(status, Is.EqualTo(HttpStatusCode.Created));
+    Assert.That(responseDocument, Is.Not.Null, nameof(responseDocument));
+    Assert.That(responseDocument!.Root!.Name.LocalName, Is.EqualTo("entry"));
+    Assert.That(responseDocument.Root!.Name.NamespaceName, Is.EqualTo(AtomPub.Namespaces.Atom.NamespaceName));
 
     var (request, _) = await task;
 
-    Assert.AreEqual(WebRequestMethods.Http.Post, request.HttpMethod, nameof(request.HttpMethod));
-    Assert.IsNotNull(request.Headers["X-WSSE"], "has X-WSSE header");
+    Assert.That(request.HttpMethod, Is.EqualTo(WebRequestMethods.Http.Post), nameof(request.HttpMethod));
+    Assert.That(request.Headers["X-WSSE"], Is.Not.Null, "has X-WSSE header");
   }
 
   [Test]
@@ -198,12 +198,12 @@ public class AtomPubClientTests {
       );
     });
 
-    Assert.AreEqual(HttpStatusCode.Unauthorized, status);
-    Assert.IsNull(responseDocument, nameof(responseDocument));
+    Assert.That(status, Is.EqualTo(HttpStatusCode.Unauthorized));
+    Assert.That(responseDocument, Is.Null, nameof(responseDocument));
 
     var (request, _) = await task;
 
-    Assert.AreEqual(WebRequestMethods.Http.Post, request.HttpMethod, nameof(request.HttpMethod));
+    Assert.That(request.HttpMethod, Is.EqualTo(WebRequestMethods.Http.Post), nameof(request.HttpMethod));
   }
 
   [Test]
@@ -235,15 +235,15 @@ public class AtomPubClientTests {
       );
     });
 
-    Assert.AreEqual(HttpStatusCode.OK, status);
-    Assert.IsNotNull(responseDocument, nameof(responseDocument));
-    Assert.AreEqual("entry", responseDocument!.Root!.Name.LocalName);
-    Assert.AreEqual(AtomPub.Namespaces.Atom.NamespaceName, responseDocument.Root!.Name.NamespaceName);
+    Assert.That(status, Is.EqualTo(HttpStatusCode.OK));
+    Assert.That(responseDocument, Is.Not.Null, nameof(responseDocument));
+    Assert.That(responseDocument!.Root!.Name.LocalName, Is.EqualTo("entry"));
+    Assert.That(responseDocument.Root!.Name.NamespaceName, Is.EqualTo(AtomPub.Namespaces.Atom.NamespaceName));
 
     var (request, _) = await task;
 
-    Assert.AreEqual(WebRequestMethods.Http.Put, request.HttpMethod, nameof(request.HttpMethod));
-    Assert.IsNotNull(request.Headers["X-WSSE"], "has X-WSSE header");
+    Assert.That(request.HttpMethod, Is.EqualTo(WebRequestMethods.Http.Put), nameof(request.HttpMethod));
+    Assert.That(request.Headers["X-WSSE"], Is.Not.Null, "has X-WSSE header");
   }
 
   [Test]
@@ -274,12 +274,12 @@ public class AtomPubClientTests {
       );
     });
 
-    Assert.AreEqual(HttpStatusCode.MethodNotAllowed, status);
-    Assert.IsNull(responseDocument, nameof(responseDocument));
+    Assert.That(status, Is.EqualTo(HttpStatusCode.MethodNotAllowed));
+    Assert.That(responseDocument, Is.Null, nameof(responseDocument));
 
     var (request, _) = await task;
 
-    Assert.AreEqual(WebRequestMethods.Http.Put, request.HttpMethod, nameof(request.HttpMethod));
+    Assert.That(request.HttpMethod, Is.EqualTo(WebRequestMethods.Http.Put), nameof(request.HttpMethod));
   }
 
   [TestCase(true)]
@@ -313,11 +313,11 @@ public class AtomPubClientTests {
 
     var (request, requestStream) = await task;
 
-    Assert.AreEqual(
-      postIfTrueOtherwisePut
-        ? WebRequestMethods.Http.Post
-        : WebRequestMethods.Http.Put,
+    Assert.That(
       request.HttpMethod,
+      Is.EqualTo(postIfTrueOtherwisePut
+        ? WebRequestMethods.Http.Post
+        : WebRequestMethods.Http.Put),
       nameof(request.HttpMethod)
     );
 
@@ -325,9 +325,9 @@ public class AtomPubClientTests {
 
     requestStream.Read(requestBodyFirst5Bytes, 0, requestBodyFirst5Bytes.Length);
 
-    CollectionAssert.AreEqual(
-      new byte[] { (byte)'<', (byte)'?', (byte)'x', (byte)'m', (byte)'l'},
+    Assert.That(
       requestBodyFirst5Bytes,
+      Is.EqualTo(new byte[] { (byte)'<', (byte)'?', (byte)'x', (byte)'m', (byte)'l' }).AsCollection,
       "request body must be sent in UTF-8 without BOM"
     );
   }

--- a/tests/Smdn.HatenaBlogTools.Core/Smdn.HatenaBlogTools.AtomPublishingProtocol/PseudoAtomPubServer.cs
+++ b/tests/Smdn.HatenaBlogTools.Core/Smdn.HatenaBlogTools.AtomPublishingProtocol/PseudoAtomPubServer.cs
@@ -17,8 +17,10 @@ internal class PseudoAtomPubServer : IDisposable {
 
   private void ThrowIfDisposed()
   {
+#pragma warning disable CA1513
     if (listener is null)
       throw new ObjectDisposedException(GetType().FullName);
+#pragma warning restore CA1513
   }
 
   public void Dispose()

--- a/tests/Smdn.HatenaBlogTools.Core/Smdn.HatenaBlogTools.Core.Tests.csproj
+++ b/tests/Smdn.HatenaBlogTools.Core/Smdn.HatenaBlogTools.Core.Tests.csproj
@@ -4,7 +4,8 @@ SPDX-License-Identifier: MIT
 -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition=" '$(EnableTargetFrameworkDotNet)' == 'true' ">net8.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(EnableTargetFrameworkDotNet80)' == 'true' ">net8.0;$(TargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(EnableTargetFrameworkDotNet60)' == 'true' ">net6.0;$(TargetFrameworks)</TargetFrameworks>
     <TargetFrameworks Condition=" '$(EnableTargetFrameworkNetFx)' == 'true' ">$(TargetFrameworks);net47</TargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/tests/Smdn.HatenaBlogTools.Core/Smdn.HatenaBlogTools.Core.Tests.csproj
+++ b/tests/Smdn.HatenaBlogTools.Core/Smdn.HatenaBlogTools.Core.Tests.csproj
@@ -4,8 +4,7 @@ SPDX-License-Identifier: MIT
 -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition=" '$(EnableTargetFrameworkDotNet)' == 'true' ">net6.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(EnableTargetFrameworkNetCoreApp)' == 'true' ">$(TargetFrameworks);netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(EnableTargetFrameworkDotNet)' == 'true' ">net8.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(EnableTargetFrameworkNetFx)' == 'true' ">$(TargetFrameworks);net47</TargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/tests/Smdn.HatenaBlogTools.Core/Smdn.HatenaBlogTools.HatenaBlog/EntryContentType.cs
+++ b/tests/Smdn.HatenaBlogTools.Core/Smdn.HatenaBlogTools.HatenaBlog/EntryContentType.cs
@@ -19,5 +19,5 @@ public class EntryContentTypeTests {
   [TestCase("TEXT/HTML", ".html")]
   [TestCase("text/x-unknown", null)]
   public void GetFileExtension(string contentType, string? expectedFileExtension)
-    => Assert.AreEqual(expectedFileExtension, EntryContentType.GetFileExtension(contentType));
+    => Assert.That(EntryContentType.GetFileExtension(contentType), Is.EqualTo(expectedFileExtension));
 }

--- a/tests/Smdn.HatenaBlogTools.Core/Smdn.HatenaBlogTools.HatenaBlog/HatenaBlogContentEditor.cs
+++ b/tests/Smdn.HatenaBlogTools.Core/Smdn.HatenaBlogTools.HatenaBlog/HatenaBlogContentEditor.cs
@@ -75,7 +75,7 @@ public class HatenaBlogContentEditorTests {
 
     editor.FixMixedContentReferences();
 
-    Assert.AreEqual(expectedResult, editor.ToString(), "modified content");
+    Assert.That(editor.ToString(), Is.EqualTo(expectedResult), "modified content");
   }
 
   [TestCase("<img src=\"https://example.com/test.dat\">",
@@ -92,7 +92,7 @@ public class HatenaBlogContentEditorTests {
 
     editor.FixMixedContentReferences();
 
-    Assert.AreEqual(expectedResult, editor.ToString(), "modified content");
+    Assert.That(editor.ToString(), Is.EqualTo(expectedResult), "modified content");
   }
 
   [TestCase("<img src=\"//example.com/test.dat\">")]
@@ -102,7 +102,7 @@ public class HatenaBlogContentEditorTests {
 
     editor.FixMixedContentReferences();
 
-    Assert.AreEqual(input, editor.ToString(), "modified content");
+    Assert.That(editor.ToString(), Is.EqualTo(input), "modified content");
   }
 
   [TestCase("<img src=\"/test.dat\">")]
@@ -114,7 +114,7 @@ public class HatenaBlogContentEditorTests {
 
     editor.FixMixedContentReferences();
 
-    Assert.AreEqual(input, editor.ToString(), "modified content");
+    Assert.That(editor.ToString(), Is.EqualTo(input), "modified content");
   }
 
   [TestCase("<img src=\"ftps://example.com/test.dat\">")]
@@ -124,7 +124,7 @@ public class HatenaBlogContentEditorTests {
 
     editor.FixMixedContentReferences();
 
-    Assert.AreEqual(input, editor.ToString(), "modified content");
+    Assert.That(editor.ToString(), Is.EqualTo(input), "modified content");
   }
 
   [TestCase("<link rel=\"canonical\" href=\"http://example.com/test.dat\">")]
@@ -134,7 +134,7 @@ public class HatenaBlogContentEditorTests {
 
     editor.FixMixedContentReferences();
 
-    Assert.AreEqual(input, editor.ToString(), "modified content");
+    Assert.That(editor.ToString(), Is.EqualTo(input), "modified content");
   }
 
   [TestCase("<a href=\"http://example.com/test.dat\">")]
@@ -146,7 +146,7 @@ public class HatenaBlogContentEditorTests {
 
     editor.FixMixedContentReferences();
 
-    Assert.AreEqual(input, editor.ToString(), "modified content");
+    Assert.That(editor.ToString(), Is.EqualTo(input), "modified content");
   }
 
   [TestCase("http://example.com/test.dat")]
@@ -158,7 +158,7 @@ public class HatenaBlogContentEditorTests {
 
     editor.FixMixedContentReferences();
 
-    Assert.AreEqual(input, editor.ToString(), "modified content");
+    Assert.That(editor.ToString(), Is.EqualTo(input), "modified content");
   }
 
   [TestCase("<img src=\"http://example.com/test.dat\">", "<img src=\"https://example.com/test.dat\">")]
@@ -169,7 +169,7 @@ public class HatenaBlogContentEditorTests {
 
     editor.FixMixedContentReferences(attribute => attribute.Value!.Contains("//example.com/"));
 
-    Assert.AreEqual(expectedResult, editor.ToString(), "modified content");
+    Assert.That(editor.ToString(), Is.EqualTo(expectedResult), "modified content");
   }
 
 
@@ -193,7 +193,7 @@ public class HatenaBlogContentEditorTests {
 
     editor.ReplaceBlogUrlToHttps(new[] { "example.com", "example.net" });
 
-    Assert.AreEqual(expectedResult, editor.ToString(), "modified content");
+    Assert.That(editor.ToString(), Is.EqualTo(expectedResult), "modified content");
   }
 
   [TestCase("http://example.net/")]
@@ -204,6 +204,6 @@ public class HatenaBlogContentEditorTests {
 
     editor.ReplaceBlogUrlToHttps(new[] { "example.com" });
 
-    Assert.AreEqual(input, editor.ToString(), "modified content");
+    Assert.That(editor.ToString(), Is.EqualTo(input), "modified content");
   }
 }

--- a/tests/Smdn.HatenaBlogTools.Core/Smdn.HatenaBlogTools.Html/HtmlDocument.cs
+++ b/tests/Smdn.HatenaBlogTools.Core/Smdn.HatenaBlogTools.Html/HtmlDocument.cs
@@ -13,8 +13,8 @@ public class HtmlDocumentTests {
   {
     var doc = new HtmlDocument(input);
 
-    Assert.IsEmpty(doc.Elements, "element count");
-    Assert.AreEqual(input, doc.ToString(), "reconstructed document");
+    Assert.That(doc.Elements, Is.Empty, "element count");
+    Assert.That(doc.ToString(), Is.EqualTo(input), "reconstructed document");
   }
 
   [TestCase("<p>")]
@@ -25,10 +25,10 @@ public class HtmlDocumentTests {
   {
     var doc = new HtmlDocument(input);
 
-    Assert.AreEqual(1, doc.Elements.Count, "element count");
-    Assert.AreEqual("p", doc.Elements[0].LocalName, "element local name #0");
+    Assert.That(doc.Elements.Count, Is.EqualTo(1), "element count");
+    Assert.That(doc.Elements[0].LocalName, Is.EqualTo("p"), "element local name #0");
 
-    Assert.AreEqual(input, doc.ToString(), "reconstructed document");
+    Assert.That(doc.ToString(), Is.EqualTo(input), "reconstructed document");
   }
 
   [TestCase("</p>")]
@@ -39,9 +39,9 @@ public class HtmlDocumentTests {
   {
     var doc = new HtmlDocument(input);
 
-    Assert.AreEqual(0, doc.Elements.Count, "element count");
+    Assert.That(doc.Elements.Count, Is.EqualTo(0), "element count");
 
-    Assert.AreEqual(input, doc.ToString(), "reconstructed document");
+    Assert.That(doc.ToString(), Is.EqualTo(input), "reconstructed document");
   }
 
   [TestCase("<p>text<p>")]
@@ -53,7 +53,7 @@ public class HtmlDocumentTests {
   {
     var doc = new HtmlDocument(input);
 
-    Assert.AreEqual(input, doc.ToString(), "reconstructed document");
+    Assert.That(doc.ToString(), Is.EqualTo(input), "reconstructed document");
   }
 
   [TestCase("<p class='parag' id='p1'>")]
@@ -72,18 +72,18 @@ public class HtmlDocumentTests {
   {
     var doc = new HtmlDocument(input);
 
-    Assert.AreEqual(1, doc.Elements.Count, "element count");
-    Assert.AreEqual("p", doc.Elements[0].LocalName, "element local name #0");
+    Assert.That(doc.Elements.Count, Is.EqualTo(1), "element count");
+    Assert.That(doc.Elements[0].LocalName, Is.EqualTo("p"), "element local name #0");
 
-    Assert.AreEqual(2, doc.Elements[0].Attributes.Count, "element #0 attribute count");
+    Assert.That(doc.Elements[0].Attributes.Count, Is.EqualTo(2), "element #0 attribute count");
 
-    Assert.AreEqual("class", doc.Elements[0].Attributes[0].Name, "element #0 attribute #0 name");
-    Assert.AreEqual("parag", doc.Elements[0].Attributes[0].Value, "element #0 attribute #0 value");
+    Assert.That(doc.Elements[0].Attributes[0].Name, Is.EqualTo("class"), "element #0 attribute #0 name");
+    Assert.That(doc.Elements[0].Attributes[0].Value, Is.EqualTo("parag"), "element #0 attribute #0 value");
 
-    Assert.AreEqual("id", doc.Elements[0].Attributes[1].Name, "element #0 attribute #1 name");
-    Assert.AreEqual("p1", doc.Elements[0].Attributes[1].Value, "element #0 attribute #1 value");
+    Assert.That(doc.Elements[0].Attributes[1].Name, Is.EqualTo("id"), "element #0 attribute #1 name");
+    Assert.That(doc.Elements[0].Attributes[1].Value, Is.EqualTo("p1"), "element #0 attribute #1 value");
 
-    Assert.AreEqual(input, doc.ToString(), "reconstructed document");
+    Assert.That(doc.ToString(), Is.EqualTo(input), "reconstructed document");
   }
 
   [TestCase("<e attr1='val1' attr2>")]
@@ -102,18 +102,18 @@ public class HtmlDocumentTests {
   {
     var doc = new HtmlDocument(input);
 
-    Assert.AreEqual(1, doc.Elements.Count, "element count");
-    Assert.AreEqual("e", doc.Elements[0].LocalName, "element local name #0");
+    Assert.That(doc.Elements.Count, Is.EqualTo(1), "element count");
+    Assert.That(doc.Elements[0].LocalName, Is.EqualTo("e"), "element local name #0");
 
-    Assert.AreEqual(2, doc.Elements[0].Attributes.Count, "element #0 attribute count");
+    Assert.That(doc.Elements[0].Attributes.Count, Is.EqualTo(2), "element #0 attribute count");
 
-    Assert.AreEqual("attr1", doc.Elements[0].Attributes[0].Name, "element #0 attribute #0 name");
-    Assert.AreEqual("val1", doc.Elements[0].Attributes[0].Value, "element #0 attribute #0 value");
+    Assert.That(doc.Elements[0].Attributes[0].Name, Is.EqualTo("attr1"), "element #0 attribute #0 name");
+    Assert.That(doc.Elements[0].Attributes[0].Value, Is.EqualTo("val1"), "element #0 attribute #0 value");
 
-    Assert.AreEqual("attr2", doc.Elements[0].Attributes[1].Name, "element #0 attribute #1 name");
-    Assert.AreEqual(null, doc.Elements[0].Attributes[1].Value, "element #0 attribute #1 value");
+    Assert.That(doc.Elements[0].Attributes[1].Name, Is.EqualTo("attr2"), "element #0 attribute #1 name");
+    Assert.That(doc.Elements[0].Attributes[1].Value, Is.EqualTo(null), "element #0 attribute #1 value");
 
-    Assert.AreEqual(input, doc.ToString(), "reconstructed document");
+    Assert.That(doc.ToString(), Is.EqualTo(input), "reconstructed document");
   }
 
   [TestCase("<e attr1 attr2='val2'>")]
@@ -132,18 +132,18 @@ public class HtmlDocumentTests {
   {
     var doc = new HtmlDocument(input);
 
-    Assert.AreEqual(1, doc.Elements.Count, "element count");
-    Assert.AreEqual("e", doc.Elements[0].LocalName, "element local name #0");
+    Assert.That(doc.Elements.Count, Is.EqualTo(1), "element count");
+    Assert.That(doc.Elements[0].LocalName, Is.EqualTo("e"), "element local name #0");
 
-    Assert.AreEqual(2, doc.Elements[0].Attributes.Count, "element #0 attribute count");
+    Assert.That(doc.Elements[0].Attributes.Count, Is.EqualTo(2), "element #0 attribute count");
 
-    Assert.AreEqual("attr1", doc.Elements[0].Attributes[0].Name, "element #0 attribute #0 name");
-    Assert.AreEqual(null, doc.Elements[0].Attributes[0].Value, "element #0 attribute #0 value");
+    Assert.That(doc.Elements[0].Attributes[0].Name, Is.EqualTo("attr1"), "element #0 attribute #0 name");
+    Assert.That(doc.Elements[0].Attributes[0].Value, Is.EqualTo(null), "element #0 attribute #0 value");
 
-    Assert.AreEqual("attr2", doc.Elements[0].Attributes[1].Name, "element #0 attribute #1 name");
-    Assert.AreEqual("val2", doc.Elements[0].Attributes[1].Value, "element #0 attribute #1 value");
+    Assert.That(doc.Elements[0].Attributes[1].Name, Is.EqualTo("attr2"), "element #0 attribute #1 name");
+    Assert.That(doc.Elements[0].Attributes[1].Value, Is.EqualTo("val2"), "element #0 attribute #1 value");
 
-    Assert.AreEqual(input, doc.ToString(), "reconstructed document");
+    Assert.That(doc.ToString(), Is.EqualTo(input), "reconstructed document");
   }
 
   [TestCase("<e attr='val'>", "<e attr='al'>")]
@@ -164,7 +164,7 @@ public class HtmlDocumentTests {
       }
     }
 
-    Assert.AreEqual(expectedResult, doc.ToString(), "reconstructed document");
+    Assert.That(doc.ToString(), Is.EqualTo(expectedResult), "reconstructed document");
   }
 
   [TestCase("<e attr='val'>", "<e attr=' val'>")]
@@ -185,6 +185,6 @@ public class HtmlDocumentTests {
       }
     }
 
-    Assert.AreEqual(expectedResult, doc.ToString(), "reconstructed document");
+    Assert.That(doc.ToString(), Is.EqualTo(expectedResult), "reconstructed document");
   }
 }

--- a/tests/Smdn.HatenaBlogTools.Core/Smdn.HatenaBlogTools.Html/HtmlParser.cs
+++ b/tests/Smdn.HatenaBlogTools.Core/Smdn.HatenaBlogTools.Html/HtmlParser.cs
@@ -23,9 +23,9 @@ public class HtmlParserTests {
   {
     var e = HtmlParser.EnumerateHtmlElementStart(input).FirstOrDefault();
 
-    Assert.IsNotNull(e);
-    Assert.AreEqual(expectedLocalName, e!.LocalName, "local name");
-    Assert.IsEmpty(e.Attributes, "attributes");
+    Assert.That(e, Is.Not.Null);
+    Assert.That(e!.LocalName, Is.EqualTo(expectedLocalName), "local name");
+    Assert.That(e.Attributes, Is.Empty, "attributes");
   }
 
   [TestCase("</p>")]
@@ -39,7 +39,7 @@ public class HtmlParserTests {
   {
     var e = HtmlParser.EnumerateHtmlElementStart(input).FirstOrDefault();
 
-    Assert.IsNull(e);
+    Assert.That(e, Is.Null);
   }
 
   [TestCase("<e>")]
@@ -52,9 +52,9 @@ public class HtmlParserTests {
   {
     var e = HtmlParser.EnumerateHtmlElementStart(input).FirstOrDefault();
 
-    Assert.IsNotNull(e);
-    Assert.AreEqual("e", e!.LocalName, "local name");
-    Assert.IsEmpty(e.Attributes, "attributes");
+    Assert.That(e, Is.Not.Null);
+    Assert.That(e!.LocalName, Is.EqualTo("e"), "local name");
+    Assert.That(e.Attributes, Is.Empty, "attributes");
   }
 
   [TestCase("<e attr>")]
@@ -73,11 +73,11 @@ public class HtmlParserTests {
   {
     var e = HtmlParser.EnumerateHtmlElementStart(input).FirstOrDefault();
 
-    Assert.IsNotNull(e);
-    Assert.AreEqual("e", e!.LocalName, "local name");
-    Assert.AreEqual(1, e.Attributes.Count, "attribute count");
-    Assert.AreEqual("attr", e.Attributes[0].Name, "attribute name #0");
-    Assert.IsNull(e.Attributes[0].Value, "attribute value #0");
+    Assert.That(e, Is.Not.Null);
+    Assert.That(e!.LocalName, Is.EqualTo("e"), "local name");
+    Assert.That(e.Attributes.Count, Is.EqualTo(1), "attribute count");
+    Assert.That(e.Attributes[0].Name, Is.EqualTo("attr"), "attribute name #0");
+    Assert.That(e.Attributes[0].Value, Is.Null, "attribute value #0");
   }
 
   [TestCase("<e attr=\"\">")]
@@ -88,11 +88,11 @@ public class HtmlParserTests {
   {
     var e = HtmlParser.EnumerateHtmlElementStart(input).FirstOrDefault();
 
-    Assert.IsNotNull(e);
-    Assert.AreEqual("e", e!.LocalName, "local name");
-    Assert.AreEqual(1, e!.Attributes.Count, "attribute count");
-    Assert.AreEqual("attr", e!.Attributes[0].Name, "attribute name #0");
-    Assert.IsEmpty(e!.Attributes[0].Value, "attribute value #0");
+    Assert.That(e, Is.Not.Null);
+    Assert.That(e!.LocalName, Is.EqualTo("e"), "local name");
+    Assert.That(e!.Attributes.Count, Is.EqualTo(1), "attribute count");
+    Assert.That(e!.Attributes[0].Name, Is.EqualTo("attr"), "attribute name #0");
+    Assert.That(e!.Attributes[0].Value, Is.Empty, "attribute value #0");
   }
 
   [TestCase("<e attr=val>")]
@@ -111,11 +111,11 @@ public class HtmlParserTests {
   {
     var e = HtmlParser.EnumerateHtmlElementStart(input).FirstOrDefault();
 
-    Assert.IsNotNull(e);
-    Assert.AreEqual("e", e!.LocalName, "local name");
-    Assert.AreEqual(1, e!.Attributes.Count, "attribute count");
-    Assert.AreEqual("attr", e!.Attributes[0].Name, "attribute name #0");
-    Assert.AreEqual("val", e!.Attributes[0].Value, "attribute value #0");
+    Assert.That(e, Is.Not.Null);
+    Assert.That(e!.LocalName, Is.EqualTo("e"), "local name");
+    Assert.That(e!.Attributes.Count, Is.EqualTo(1), "attribute count");
+    Assert.That(e!.Attributes[0].Name, Is.EqualTo("attr"), "attribute name #0");
+    Assert.That(e!.Attributes[0].Value, Is.EqualTo("val"), "attribute value #0");
   }
 
   [TestCase("<e attr=val>")]
@@ -151,11 +151,11 @@ public class HtmlParserTests {
   {
     var e = HtmlParser.EnumerateHtmlElementStart(input).FirstOrDefault();
 
-    Assert.IsNotNull(e);
-    Assert.AreEqual("e", e!.LocalName, "local name");
-    Assert.AreEqual(1, e!.Attributes.Count, "attribute count");
-    Assert.AreEqual("attr", e!.Attributes[0].Name, "attribute name #0");
-    Assert.AreEqual("val", e!.Attributes[0].Value, "attribute value #0");
+    Assert.That(e, Is.Not.Null);
+    Assert.That(e!.LocalName, Is.EqualTo("e"), "local name");
+    Assert.That(e!.Attributes.Count, Is.EqualTo(1), "attribute count");
+    Assert.That(e!.Attributes[0].Name, Is.EqualTo("attr"), "attribute name #0");
+    Assert.That(e!.Attributes[0].Value, Is.EqualTo("val"), "attribute value #0");
   }
 
   [TestCase("<e\tattr=val>")]
@@ -182,11 +182,11 @@ public class HtmlParserTests {
   {
     var e = HtmlParser.EnumerateHtmlElementStart(input).FirstOrDefault();
 
-    Assert.IsNotNull(e);
-    Assert.AreEqual("e", e!.LocalName, "local name");
-    Assert.AreEqual(1, e!.Attributes.Count, "attribute count");
-    Assert.AreEqual("attr", e!.Attributes[0].Name, "attribute name #0");
-    Assert.AreEqual("val", e!.Attributes[0].Value, "attribute value #0");
+    Assert.That(e, Is.Not.Null);
+    Assert.That(e!.LocalName, Is.EqualTo("e"), "local name");
+    Assert.That(e!.Attributes.Count, Is.EqualTo(1), "attribute count");
+    Assert.That(e!.Attributes[0].Name, Is.EqualTo("attr"), "attribute name #0");
+    Assert.That(e!.Attributes[0].Value, Is.EqualTo("val"), "attribute value #0");
   }
 
   [TestCase("<e attr=\"foo=bar\">")]
@@ -195,11 +195,11 @@ public class HtmlParserTests {
   {
     var e = HtmlParser.EnumerateHtmlElementStart(input).FirstOrDefault();
 
-    Assert.IsNotNull(e);
-    Assert.AreEqual("e", e!.LocalName, "local name");
-    Assert.AreEqual(1, e!.Attributes.Count, "attribute count");
-    Assert.AreEqual("attr", e!.Attributes[0].Name, "attribute name #0");
-    Assert.AreEqual("foo=bar", e!.Attributes[0].Value, "attribute value #0");
+    Assert.That(e, Is.Not.Null);
+    Assert.That(e!.LocalName, Is.EqualTo("e"), "local name");
+    Assert.That(e!.Attributes.Count, Is.EqualTo(1), "attribute count");
+    Assert.That(e!.Attributes[0].Name, Is.EqualTo("attr"), "attribute name #0");
+    Assert.That(e!.Attributes[0].Value, Is.EqualTo("foo=bar"), "attribute value #0");
   }
 
   [TestCase("<e attr=\"<foo>\">")]
@@ -208,11 +208,11 @@ public class HtmlParserTests {
   {
     var e = HtmlParser.EnumerateHtmlElementStart(input).FirstOrDefault();
 
-    Assert.IsNotNull(e);
-    Assert.AreEqual("e", e!.LocalName, "local name");
-    Assert.AreEqual(1, e!.Attributes.Count, "attribute count");
-    Assert.AreEqual("attr", e!.Attributes[0].Name, "attribute name #0");
-    Assert.AreEqual("<foo>", e!.Attributes[0].Value, "attribute value #0");
+    Assert.That(e, Is.Not.Null);
+    Assert.That(e!.LocalName, Is.EqualTo("e"), "local name");
+    Assert.That(e!.Attributes.Count, Is.EqualTo(1), "attribute count");
+    Assert.That(e!.Attributes[0].Name, Is.EqualTo("attr"), "attribute name #0");
+    Assert.That(e!.Attributes[0].Value, Is.EqualTo("<foo>"), "attribute value #0");
   }
 
   [TestCase("<e attr1 attr2>")]
@@ -224,16 +224,16 @@ public class HtmlParserTests {
   {
     var e = HtmlParser.EnumerateHtmlElementStart(input).FirstOrDefault();
 
-    Assert.IsNotNull(e);
-    Assert.AreEqual("e", e!.LocalName, "local name");
+    Assert.That(e, Is.Not.Null);
+    Assert.That(e!.LocalName, Is.EqualTo("e"), "local name");
 
-    Assert.AreEqual(2, e!.Attributes.Count, "attribute count");
+    Assert.That(e!.Attributes.Count, Is.EqualTo(2), "attribute count");
 
-    Assert.AreEqual("attr1", e!.Attributes[0].Name, "attribute name #0");
-    Assert.IsNull(e!.Attributes[0]!.Value, "attribute value #0");
+    Assert.That(e!.Attributes[0].Name, Is.EqualTo("attr1"), "attribute name #0");
+    Assert.That(e!.Attributes[0]!.Value, Is.Null, "attribute value #0");
 
-    Assert.AreEqual("attr2", e!.Attributes[1].Name, "attribute name #1");
-    Assert.IsNull(e!.Attributes[1]!.Value, "attribute value #1");
+    Assert.That(e!.Attributes[1].Name, Is.EqualTo("attr2"), "attribute name #1");
+    Assert.That(e!.Attributes[1]!.Value, Is.Null, "attribute value #1");
   }
 
   [TestCase("<e attr1=val1 attr2=val2>")]
@@ -247,16 +247,16 @@ public class HtmlParserTests {
   {
     var e = HtmlParser.EnumerateHtmlElementStart(input).FirstOrDefault();
 
-    Assert.IsNotNull(e);
-    Assert.AreEqual("e", e!.LocalName, "local name");
+    Assert.That(e, Is.Not.Null);
+    Assert.That(e!.LocalName, Is.EqualTo("e"), "local name");
 
-    Assert.AreEqual(2, e!.Attributes.Count, "attribute count");
+    Assert.That(e!.Attributes.Count, Is.EqualTo(2), "attribute count");
 
-    Assert.AreEqual("attr1", e.Attributes[0].Name, "attribute name #0");
-    Assert.AreEqual("val1", e.Attributes[0].Value, "attribute value #0");
+    Assert.That(e.Attributes[0].Name, Is.EqualTo("attr1"), "attribute name #0");
+    Assert.That(e.Attributes[0].Value, Is.EqualTo("val1"), "attribute value #0");
 
-    Assert.AreEqual("attr2", e.Attributes[1].Name, "attribute name #1");
-    Assert.AreEqual("val2", e.Attributes[1].Value, "attribute name #1");
+    Assert.That(e.Attributes[1].Name, Is.EqualTo("attr2"), "attribute name #1");
+    Assert.That(e.Attributes[1].Value, Is.EqualTo("val2"), "attribute name #1");
   }
 
   [TestCase("<p><br></p>")]
@@ -267,14 +267,14 @@ public class HtmlParserTests {
   {
     var elements = HtmlParser.EnumerateHtmlElementStart(input).ToList();
 
-    Assert.IsNotEmpty(elements);
-    Assert.AreEqual(2, elements.Count);
+    Assert.That(elements, Is.Not.Empty);
+    Assert.That(elements.Count, Is.EqualTo(2));
 
-    Assert.AreEqual("p", elements[0].LocalName, "local name #0");
-    Assert.IsEmpty(elements[0].Attributes, "attributes #0");
+    Assert.That(elements[0].LocalName, Is.EqualTo("p"), "local name #0");
+    Assert.That(elements[0].Attributes, Is.Empty, "attributes #0");
 
-    Assert.AreEqual("br", elements[1].LocalName, "local name #1");
-    Assert.IsEmpty(elements[1].Attributes, "attributes #1");
+    Assert.That(elements[1].LocalName, Is.EqualTo("br"), "local name #1");
+    Assert.That(elements[1].Attributes, Is.Empty, "attributes #1");
   }
 
   [TestCase("<p class='para' id='p1'><br></p>")]
@@ -282,20 +282,20 @@ public class HtmlParserTests {
   {
     var elements = HtmlParser.EnumerateHtmlElementStart(input).ToList();
 
-    Assert.IsNotEmpty(elements);
-    Assert.AreEqual(2, elements.Count);
+    Assert.That(elements, Is.Not.Empty);
+    Assert.That(elements.Count, Is.EqualTo(2));
 
-    Assert.AreEqual("p", elements[0].LocalName, "local name #0");
-    Assert.AreEqual(2, elements[0].Attributes.Count(), "attribute count #0");
+    Assert.That(elements[0].LocalName, Is.EqualTo("p"), "local name #0");
+    Assert.That(elements[0].Attributes.Count(), Is.EqualTo(2), "attribute count #0");
 
-    Assert.AreEqual("class", elements[0].Attributes[0].Name, "attribute name #0");
-    Assert.AreEqual("para", elements[0].Attributes[0].Value, "attribute value #0");
+    Assert.That(elements[0].Attributes[0].Name, Is.EqualTo("class"), "attribute name #0");
+    Assert.That(elements[0].Attributes[0].Value, Is.EqualTo("para"), "attribute value #0");
 
-    Assert.AreEqual("id", elements[0].Attributes[1].Name, "attribute name #1");
-    Assert.AreEqual("p1", elements[0].Attributes[1].Value, "attribute value #1");
+    Assert.That(elements[0].Attributes[1].Name, Is.EqualTo("id"), "attribute name #1");
+    Assert.That(elements[0].Attributes[1].Value, Is.EqualTo("p1"), "attribute value #1");
 
-    Assert.AreEqual("br", elements[1].LocalName, "local name #1");
-    Assert.IsEmpty(elements[1].Attributes, "attributes #1");
+    Assert.That(elements[1].LocalName, Is.EqualTo("br"), "local name #1");
+    Assert.That(elements[1].Attributes, Is.Empty, "attributes #1");
   }
 
   [TestCase("<p><i><b>")]
@@ -305,16 +305,16 @@ public class HtmlParserTests {
   {
     var elements = HtmlParser.EnumerateHtmlElementStart(input).ToList();
 
-    Assert.IsNotEmpty(elements);
-    Assert.AreEqual(3, elements.Count);
+    Assert.That(elements, Is.Not.Empty);
+    Assert.That(elements.Count, Is.EqualTo(3));
 
-    Assert.AreEqual("p", elements[0].LocalName, "local name #0");
-    Assert.IsEmpty(elements[0].Attributes, "attributes #0");
+    Assert.That(elements[0].LocalName, Is.EqualTo("p"), "local name #0");
+    Assert.That(elements[0].Attributes, Is.Empty, "attributes #0");
 
-    Assert.AreEqual("i", elements[1].LocalName, "local name #1");
-    Assert.IsEmpty(elements[1].Attributes, "attributes #1");
+    Assert.That(elements[1].LocalName, Is.EqualTo("i"), "local name #1");
+    Assert.That(elements[1].Attributes, Is.Empty, "attributes #1");
 
-    Assert.AreEqual("b", elements[2].LocalName, "local name #2");
-    Assert.IsEmpty(elements[2].Attributes, "attributes #2");
+    Assert.That(elements[2].LocalName, Is.EqualTo("b"), "local name #2");
+    Assert.That(elements[2].Attributes, Is.Empty, "attributes #2");
   }
 }

--- a/tests/TargetFrameworks.props
+++ b/tests/TargetFrameworks.props
@@ -6,27 +6,44 @@ SPDX-License-Identifier: MIT
   <PropertyGroup>
     <!-- enable target framework net* (.NET >= 5.0) by default -->
     <EnableTargetFrameworkDotNet>true</EnableTargetFrameworkDotNet>
-    <!-- enable target framework netcoreapp* by default -->
-    <EnableTargetFrameworkNetCoreApp>true</EnableTargetFrameworkNetCoreApp>
+    <EnableTargetFrameworkDotNet60>true</EnableTargetFrameworkDotNet60>
+    <EnableTargetFrameworkDotNet80>true</EnableTargetFrameworkDotNet80>
     <!-- enable target framework net* (.NET Framework/Mono) by default -->
     <EnableTargetFrameworkNetFx>true</EnableTargetFrameworkNetFx>
   </PropertyGroup>
 
+  <!--
+    Note: RuntimeInformation.RuntimeIdentifier on >= .NET 8 has been changed to return 'linux-x64' instead of 'ubuntu.20.04-x64'.
+    RuntimeInformation.OSDescription still returns 'Ubuntu 22.04' on >= .NET 8.
+  -->
+
   <!-- On Ubuntu 22.04 -->
   <PropertyGroup
-    Condition=" $([System.Runtime.InteropServices.RuntimeInformation]::RuntimeIdentifier.StartsWith('ubuntu.22.04')) "
+    Condition="
+      $([System.Runtime.InteropServices.RuntimeInformation]::RuntimeIdentifier.StartsWith('ubuntu.22.04')) or
+      $([System.Runtime.InteropServices.RuntimeInformation]::OSDescription.StartsWith('Ubuntu 22.04'))
+    "
   >
-    <!-- disable .NET Core (cannot run .NET Core on Ubuntu 22.04) -->
-    <EnableTargetFrameworkNetCoreApp>false</EnableTargetFrameworkNetCoreApp>
     <!-- disable Mono (test runner not working on local environment?) -->
-    <EnableTargetFrameworkNetFx>false</EnableTargetFrameworkNetFx>
+    <EnableTargetFrameworkNetFx Condition=" '$(GITHUB_ACTIONS)' != 'true' ">false</EnableTargetFrameworkNetFx>
   </PropertyGroup>
 
-  <!-- On Ubuntu 20.04 -->
+  <!-- On Ubuntu 24.04 -->
   <PropertyGroup
-    Condition=" $([System.Runtime.InteropServices.RuntimeInformation]::RuntimeIdentifier.StartsWith('ubuntu.20.04')) "
+    Condition="
+      $([System.Runtime.InteropServices.RuntimeInformation]::RuntimeIdentifier.StartsWith('ubuntu.24.04')) or
+      $([System.Runtime.InteropServices.RuntimeInformation]::OSDescription.StartsWith('Ubuntu 24.04'))
+    "
   >
-    <!-- enable Mono on GitHub Actions -->
-    <EnableTargetFrameworkNetFx Condition=" '$(GITHUB_ACTIONS)' == 'true' ">true</EnableTargetFrameworkNetFx>
+    <!-- disable net6.0 on GitHub Actions Ubuntu 24.04 runner images -->
+    <EnableTargetFrameworkDotNet60 Condition=" '$(GITHUB_ACTIONS)' == 'true' ">false</EnableTargetFrameworkDotNet60>
+    <!-- disable Mono on GitHub Actions Ubuntu 24.04 runner images -->
+    <EnableTargetFrameworkNetFx Condition=" '$(GITHUB_ACTIONS)' == 'true' ">false</EnableTargetFrameworkNetFx>
+  </PropertyGroup>
+
+  <!-- On MacOS -->
+  <PropertyGroup Condition="$([System.OperatingSystem]::IsMacOS())">
+    <!-- disable net6.0 on GitHub Actions MacOS runner images -->
+    <EnableTargetFrameworkDotNet60 Condition=" '$(GITHUB_ACTIONS)' == 'true' ">false</EnableTargetFrameworkDotNet60>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
### Description
- TargetFrameworksにnet8.0を追加し、netcoreapp3.1を削除する
- 使用するframework versionをnet8.0にする
- 合わせて
  - 関連ライブラリのバージョンを上げる
  - テストコードをconstraint-basedに書き換える
  - 軽微な動作不良を修正する
